### PR TITLE
(Port) FlexForm and StringInput: styles and rich text editor

### DIFF
--- a/src/components/flexForm/FlexForm.tsx
+++ b/src/components/flexForm/FlexForm.tsx
@@ -212,7 +212,7 @@ function FlexForm(props: IFlexFormProps) {
           props.grid?.styles ||
           `grid grid-cols-${
             props.grid?.columnCount ?? '3'
-          } gap-x-12 gap-y-8 justify-items-stretch`
+          } gap-x-12 gap-y-8 justify-items-stretch mb-5`
         }
       >
         {...fieldsElements}

--- a/src/components/flexForm/FlexForm.tsx
+++ b/src/components/flexForm/FlexForm.tsx
@@ -207,10 +207,13 @@ function FlexForm(props: IFlexFormProps) {
 
   return (
     <form onSubmit={handleSubmit(props.onSubmit ?? onSubmit)} className={`flex flex-col p-8`}>
-      <div
-        className={`grid grid-cols-${props.grid?.columnCount ?? '3'} gap-x-12 gap-y-8 justify-items-stretch ${
-          props.grid?.styles || ''
-        }`}
+     <div
+        className={
+          props.grid?.styles ||
+          `grid grid-cols-${
+            props.grid?.columnCount ?? '3'
+          } gap-x-12 gap-y-8 justify-items-stretch`
+        }
       >
         {...fieldsElements}
       </div>


### PR DESCRIPTION
Ported from current project. Commit messages should tell story too but expanding here:

FlexForm

- allows grid style prop to override styles instead of simply appending
- Adds a default margin to the bottom of the grid to help space out inputs from the submit button

StringInput

- Adds the PrimeReact rich text editor as an option for string types and provides a default toolbar header (can override with `passThroughProps`)


#### Screenshots

Rich Text input with new default margin
![image](https://user-images.githubusercontent.com/485809/139124315-b5ad7966-678c-4cdc-9c84-0aebf8588fb1.png)


Rich Text input with old spacing
![image](https://user-images.githubusercontent.com/485809/139124058-6ea5ba59-f302-4bae-a2af-d5fc29b3f8da.png)
