### PR TITLE
Flexform Bugfix/Feature:  Converts timestamps displayed in fields and allows custom preprocessing

### DIFF
--- a/src/components/flexForm/FlexFormLocal.tsx
+++ b/src/components/flexForm/FlexFormLocal.tsx
@@ -32,15 +32,74 @@ export interface FlexFormLocalProps {
       [key: string]: any;
       rules?: Omit<RegisterOptions, 'valueAsNumber' | 'valueAsDate' | 'setValueAs' | 'disabled'>;
     }
-  >;
-  onDataFromGrid?: (data: any) => void;
-  control: Control;
+  >
+  onDataFromGrid?: (data: any) => void
+  control?: Control,
+  /**
+   * Pass in the name of the field you wish to prepocess, and a function that returns a value.
+   * This value will be used to process the associated data _before_ setting the default value
+   * in the form. Any values in here will override default preprocessing
+   *
+   * Current Defaults:
+   * timestamp, timestamptz -> converts from string to js Date object
+  */
+  preprocessData?: Record<string, (data: any) => any>
 }
 
 function FlexFormLocal(props: FlexFormLocalProps) {
   const rgUIContext = useContext<any>(ReactGraphqlUIContext);
   //Spread primary key onto initial variables for update
-  const { fields: fieldsConfig, configs, data, onDataFromGrid, props: passthroughProps, control } = props;
+  const {
+    fields: fieldsConfig,
+    configs,
+    data: _data,
+    preprocessData,
+    onDataFromGrid,
+    props: passthroughProps,
+    control,
+  } = props
+
+  const data = useMemo(() => {
+    // Grab a deep copy of _data. We want that to compare to the original if needed.
+    let data = _data
+    if (typeof _data === 'object' && !Array.isArray(_data)) {
+      data = { ..._data }
+    } else {
+      return null
+    }
+
+    // PreProcess with some defaults. For instance if there's a timestamp field
+    // the default preprocessing is to convert it into a Date object.
+    // If that is undesirable a user can overrid that by providing a custom preprocess function to simply return the value
+    for (const [datumName, datumValue] of Object.entries(_data)) {
+      // const datumTypeName = fieldsConfig?.fieldSimpleMap?.[datumName]?.typeName
+      const datumTypeName = fieldsConfig.find(
+        (field: FlexFormFieldOutputType) => field.name === datumName
+      )?.typeName
+
+      // Convert timestamps to Date objects
+      if (
+        typeof datumValue === 'string' &&
+        (datumTypeName === 'timestamp' || datumTypeName === 'timestamptz')
+      ) {
+        data[datumName] = new Date(datumValue)
+      }
+    }
+
+    // Custom pre-processing. Overrides changes made by default preprocessors by reading from _data directly
+    // If user needs to transform the data before it populates the form. EG: string to date
+    if (preprocessData) {
+      // Go through all their transforms
+      for (const [dataName, dataTransform] of Object.entries(preprocessData)) {
+        // If that field name exists
+        if (dataName in _data) {
+          //.. apply the transformation
+          data[dataName] = dataTransform(_data[dataName])
+        }
+      }
+    }
+    return data
+  }, [_data])
 
   useEffect(() => {
     if (onDataFromGrid) {


### PR DESCRIPTION
Data is preprocessed (and memoized) before setting default values for the form.

This fixes an issue where components such as PrimeReact's Calendar are expecting an object, not the primitive stored in Hasura.

By default this transforms timestamps, but that behaviour can be overridden by the developer.

This also allows for complex objects stored in Jsonb columns to be transformed into an instance of an object if an instance of a class with functions is expected by a component