### PR TITLE
fix(usedatatable): Upsert Dialog now shows if insert OR update is enabled

### DIFF
--- a/src/hooks/datatable/useDataTable.tsx
+++ b/src/hooks/datatable/useDataTable.tsx
@@ -227,7 +227,8 @@ export default function useDataTable<T = Record<string, any>>(
 
   //upsertDialog
   const upsertDialog = useMemo(() => {
-    if (!needsActionColumn) {
+    // Only include upsert dialog when updating or inserting is enabled
+    if (!args?.update && !args?.insert) {
       return null;
     }
 


### PR DESCRIPTION
Bug: If you _only_ set `insert: true` the "new" button will not do anything as the dialog is not returned. The workaround is to always set `update`.
