### PR TITLE
enhance(support): Better error message for debugging flexforms

### DIFF
--- a/src/support/getDefaultComponentForScalar.tsx
+++ b/src/support/getDefaultComponentForScalar.tsx
@@ -9,6 +9,18 @@ export function getDefaultComponentForScalar(
 ) {
   const fieldMetaLookup = config.fields?.fieldSimpleMap ?? {};
   const fieldInfo = fieldMetaLookup[field];
+  if (!fieldInfo) {
+    throw new Error(`🔍Cannot find fieldInfo for field named "${field}" in the Hasura Config provided for "${
+      config?.typename
+    }"
+    + Did you make a typo or use the incorrect name for the field?
+    + Confirm you included the field in your fragment
+
+    🐛 Field names found in config (alphabetical):
+    [${Object.keys(config?.fields?.fieldSimpleMap ?? {})
+      .sort()
+      .join(', ')}]`)
+  }
   const fieldTypePascal = Case.pascal(fieldInfo.typeName);
 
   const defaultComponent = defaultScalarComponents[fieldTypePascal + 'Input'];


### PR DESCRIPTION
I realized instead of letting this error on `fieldInfo.typeName` if fieldInfo was undefined it would be better to throw a custom error ourselves with more detailed debug info