### PR TITLE
feat: Add display name for the react devtools extension

### DIFF
--- a/src/context/ReactGraphqlUIContext.tsx
+++ b/src/context/ReactGraphqlUIContext.tsx
@@ -20,3 +20,4 @@ export const ReactGraphqlUIContext = React.createContext<IReactGraphqlUIContext>
   },
   configsMap: {},
 });
+ReactGraphqlUIContext.displayName = "ReactGraphqlUIContext";


### PR DESCRIPTION
Makes it easier to know what context the provider is for

https://reactjs.org/docs/context.html#contextdisplayname

New visual:
![image](https://user-images.githubusercontent.com/485809/144529975-00534bd0-051f-40e1-b053-8fee00fc9015.png)

Current visual:
![image](https://user-images.githubusercontent.com/485809/144529714-58216e9e-9927-48fe-8aa0-0fa51c8ea96f.png)

