### PR TITLE
feat: Add reload button for datatable

### DIFF
--- a/src/hooks/datatable/useDataTable.tsx
+++ b/src/hooks/datatable/useDataTable.tsx
@@ -107,10 +107,12 @@ export interface UseDataTableArgs<T> {
     left?:
       | 'searchInput'
       | 'insertButton'
+      | 'refresh'
       | ((toolbarOptions: ToolbarOptions) => JSX.Element);
     right?:
       | 'searchInput'
       | 'insertButton'
+      | 'refresh'
       | ((toolbarOptions: ToolbarOptions) => JSX.Element);
     whereBuilder?: (searchText: string | undefined, event?: DataTableFilterParams) => Record<string, any>;
     debounceMS?: number;
@@ -185,8 +187,7 @@ export default function useDataTable<T = Record<string, any>>(
     : useReactGraphql(gqlConfig).useInfiniteQueryMany<T>({isInfinite: false, ...queryArgs});
 
 
-
-  const paginationProps = useDataTablePagination({
+  const {onRefresh: refreshPaginatedTable ,...paginationProps} = useDataTablePagination({
     queryManyState: queryManyState,
     pageSize: pageSize,
     queryArgsAtom: queryArgsAtom || backupAtom,
@@ -242,6 +243,9 @@ export default function useDataTable<T = Record<string, any>>(
     args.toolbar?.left === 'insertButton' ||
     args.toolbar?.right === 'insertButton';
 
+  const needsRefreshButton =
+    args.toolbar?.left === 'refresh' || args.toolbar?.right === 'refresh';
+
   const insertButton = useMemo(() => {
     if (!needsInsertButton) {
       return;
@@ -255,6 +259,19 @@ export default function useDataTable<T = Record<string, any>>(
       />
     );
   }, [needsInsertButton]);
+
+  const refreshButton = useMemo(() => {
+    if (!needsRefreshButton) {
+      return;
+    }
+    return (
+      <Button
+        icon="pi pi-refresh"
+        className="p-button-text"
+        onClick={refreshPaginatedTable}
+      />
+    );
+  }, [needsRefreshButton])
 
   const toolbarComponent = useMemo(() => {
     let left;
@@ -274,6 +291,12 @@ export default function useDataTable<T = Record<string, any>>(
       );
     }
 
+    if (args.toolbar?.left === 'refresh') {
+      left = refreshButton;
+    }
+    if (args.toolbar?.right === 'refresh') {
+      right = refreshButton;
+    }
     if (
       args.insert === 'toolBarLeft' ||
       args.toolbar?.left === 'insertButton'

--- a/src/hooks/datatable/useDataTablePagination.tsx
+++ b/src/hooks/datatable/useDataTablePagination.tsx
@@ -14,6 +14,7 @@ export interface DataTablePaginationProps<T> {
   lazy: boolean
   first: number
   currentRows: T[]
+  onRefresh?: () => void
 }
 
 export default function useDataTablePagination<T = any>(args: {
@@ -58,6 +59,10 @@ export default function useDataTablePagination<T = any>(args: {
       ...event,
     })
   }
+
+  const onRefresh = () => {
+    args.queryManyState?.refresh();
+  };
 
   useEffect(() => {
     setLazyParams({
@@ -181,6 +186,7 @@ export default function useDataTablePagination<T = any>(args: {
     loading: args.queryManyState?.queryState?.fetching,
     first: lazyParams.first,
     currentRows,
+    onRefresh,
     // rowsPerPageOptions: [50],
   }
 }


### PR DESCRIPTION
- Added 'refresh' as posible parameter in toolbar
- changes in useDataTablePagination to return onRefresh function
- Added button as text-button and following the same structure as insertButton

<img width="1151" alt="Screen Shot 2021-12-29 at 16 41 04" src="https://user-images.githubusercontent.com/31198370/147705495-a624af75-c0da-4d1b-b11d-496754a60de8.png">

