### PR TITLE
fix: wherebuilder for searchbar overwrote queryargs

### DIFF
--- a/src/hooks/datatable/useDataTable.tsx
+++ b/src/hooks/datatable/useDataTable.tsx
@@ -200,6 +200,7 @@ export default function useDataTable<T = Record<string, any>>(
     gqlConfig,
     queryArgsAtom: queryArgsAtom || backupAtom,
     dataTableArgs: args,
+    queryArgsWhere: args.queryArgs?.where,
   });
 
   const tableProps = useMemo<DataTableSpreadableProps>(() => {

--- a/src/hooks/datatable/useDataTableWhere.tsx
+++ b/src/hooks/datatable/useDataTableWhere.tsx
@@ -40,6 +40,7 @@ export default function useDataTableWhere<T>(args: {
   queryArgsAtom: PrimitiveAtom<UseDataTableQueryArgsAtom>;
   gqlConfig?: HasuraDataConfig;
   dataTableArgs?: UseDataTableArgs<T>;
+  queryArgsWhere?: Record<string, any>;
 }): UseDataTableWhere<T> {
   const [queryArgs, setQueryArgs] = useAtom(args.queryArgsAtom);
   const [lastEvent, setLastEvent] = useState<DataTableFilterParams>();
@@ -82,7 +83,7 @@ export default function useDataTableWhere<T>(args: {
 
     setQueryArgs({
       ...queryArgs,
-      where: whereClause,
+      where: { _and: [whereClause , args.queryArgsWhere || {}] },
     });
   };
 
@@ -131,7 +132,7 @@ export default function useDataTableWhere<T>(args: {
     if (where || queryArgs.where) {
       setQueryArgs({
         ...queryArgs,
-        where,
+        where: { _and: [where , args.queryArgsWhere || {}] },
       });
     }
   }, [where]);


### PR DESCRIPTION
- This behavior was happening even if searchbar was not used
- arg added in useDataTableWhere hook for keep the previous `queryArgs.where` value
- added builder using and for where in setQueryArgs

previous behavior:
before the changes the overwrite of queryArgs caused the parameter where within it to have no effect.
<img width="1399" alt="Screen Shot 2021-12-30 at 00 44 31" src="https://user-images.githubusercontent.com/31198370/147724893-61572d89-8c25-4393-84c2-36a6555fcd15.png">


after the changes the behavior was not repeated, and queryargs and searchbar were able to work together
<img width="1114" alt="Screen Shot 2021-12-30 at 00 48 20" src="https://user-images.githubusercontent.com/31198370/147725106-7629715c-57be-45da-8dfc-6e652de7a51a.png">
<img width="1111" alt="Screen Shot 2021-12-30 at 00 50 03" src="https://user-images.githubusercontent.com/31198370/147725225-a855f586-f6d6-4b28-b58c-83fdca1626c4.png">

