### PR TITLE
Enable float values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tesseractcollective/react-graphql-ui",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "A library built on top of react-graphql to give you various components and hooks to help speed up development. Currently include features for DataTables, Forms, and Dropdowns based on DB relationships",
   "keywords": [
     "graphql",

--- a/src/scalarComponents/primereact/FloatInput.tsx
+++ b/src/scalarComponents/primereact/FloatInput.tsx
@@ -1,12 +1,12 @@
-import React, { FunctionComponent } from "react";
-import { bs } from "@tesseractcollective/react-graphql";
-import { ScalarComponentPropsBase } from "../../types/generic";
-import NumberInput from "./NumberInput";
+import React, { FunctionComponent } from 'react'
+import { bs } from '@tesseractcollective/react-graphql'
+import { ScalarComponentPropsBase } from '../../types/generic'
+import NumberInput from './NumberInput'
 
 export interface IFloatInputProps extends ScalarComponentPropsBase {}
 
 const FloatInput: FunctionComponent<IFloatInputProps> = function FloatInput(
-  props
+  props: any
 ) {
   return (
     <NumberInput
@@ -18,7 +18,7 @@ const FloatInput: FunctionComponent<IFloatInputProps> = function FloatInput(
         ...props,
       }}
     />
-  );
-};
+  )
+}
 
-export default FloatInput;
+export default FloatInput

--- a/src/scalarComponents/primereact/FloatInput.tsx
+++ b/src/scalarComponents/primereact/FloatInput.tsx
@@ -1,7 +1,7 @@
-import React, { FunctionComponent } from 'react'
-import { bs } from '@tesseractcollective/react-graphql'
-import { ScalarComponentPropsBase } from '../../types/generic';
-import NumberInput from './NumberInput'
+import React, { FunctionComponent } from "react";
+import { bs } from "@tesseractcollective/react-graphql";
+import { ScalarComponentPropsBase } from "../../types/generic";
+import NumberInput from "./NumberInput";
 
 export interface IFloatInputProps extends ScalarComponentPropsBase {}
 
@@ -14,10 +14,11 @@ const FloatInput: FunctionComponent<IFloatInputProps> = function FloatInput(
       {...props}
       inputNumberProps={{
         maxFractionDigits: 2,
-        ...props
+        minFractionDigits: 2,
+        ...props,
       }}
     />
-  )
-}
+  );
+};
 
-export default FloatInput
+export default FloatInput;


### PR DESCRIPTION
this one-liner PR enables the user to input decimal values in Flex Form Local Fields with `typeName: float8`