### PR TITLE
fix: items fail to load on page that reaches the loaded items

### DIFF
--- a/src/hooks/datatable/useDataTablePagination.tsx
+++ b/src/hooks/datatable/useDataTablePagination.tsx
@@ -50,7 +50,7 @@ export default function useDataTablePagination<T = any>(args: {
     )
     if (
       event.page >= lazyParams.page &&
-      event.page * pageSize >= (args.queryManyState?.items?.length || 0)
+      event.first + pageSize >= (args.queryManyState?.items?.length || 0)
     ) {
       args.queryManyState?.loadNextPage()
     }

--- a/src/hooks/datatable/useDataTablePagination.tsx
+++ b/src/hooks/datatable/useDataTablePagination.tsx
@@ -48,12 +48,6 @@ export default function useDataTablePagination<T = any>(args: {
       pageCount:${event.pageCount}    rows:${event.rows}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~`
     )
-    if (
-      event.page >= lazyParams.page &&
-      event.first + pageSize > (args.queryManyState?.items?.length || 0)
-    ) {
-      args.queryManyState?.loadNextPage()
-    }
     setLazyParams({
       ...lazyParams,
       ...event,
@@ -168,6 +162,13 @@ export default function useDataTablePagination<T = any>(args: {
     },
   }
 
+  useEffect(()=>{
+    const endIndex = lazyParams.first + pageSize
+    if ( endIndex > (args.queryManyState?.items?.length || 0) ) {
+      args.queryManyState?.loadNextPage()
+    }
+  }, [lazyParams, args.queryManyState?.items])
+  
   const currentRows = useMemo(() => {
     const startIndex = lazyParams.first
     const endIndex = lazyParams.first + pageSize

--- a/src/hooks/datatable/useDataTablePagination.tsx
+++ b/src/hooks/datatable/useDataTablePagination.tsx
@@ -50,7 +50,7 @@ export default function useDataTablePagination<T = any>(args: {
     )
     if (
       event.page >= lazyParams.page &&
-      event.first + pageSize >= (args.queryManyState?.items?.length || 0)
+      event.first + pageSize > (args.queryManyState?.items?.length || 0)
     ) {
       args.queryManyState?.loadNextPage()
     }


### PR DESCRIPTION
- change in useDataTablePagination hook for load items using first item index and pagesize (last item index) instead of page number

previous behavior:
we can see logs for 2 different pages
1. the first one covers from item 20 to 39, in this case isn't necessary load more elements, since they don't exceeded the 50 elements previously loaded
2. the second one covers from item 40 to 59, in this case is necessary load more elements, but due to a miscalculation this does not happen (the index of the page and rows per page are used to know if the limit has been exceeded: 2*20 !> 50 )
<img width="1000" alt="Screen Shot 2022-01-24 at 16 56 49" src="https://user-images.githubusercontent.com/31198370/150871709-2ee4ec14-6979-497e-ace0-4c0e9dde2e1f.png">

behavior with changes in this PR:
we can see logs for 2 different pages
1. same behavior as before the changes
2. behavior is corrected and more items are loaded (the index of the last element of the page is used to know if the limit has been exceeded: 59>50 => loadNextPage )
<img width="1000" alt="Screen Shot 2022-01-24 at 16 54 51" src="https://user-images.githubusercontent.com/31198370/150871479-ba22678e-c07a-42fe-8b5b-ae3c2d22ad3a.png">

