### PR TITLE
fix: both float and float8 types now accept decimal values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tesseractcollective/react-graphql-ui",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "A library built on top of react-graphql to give you various components and hooks to help speed up development. Currently include features for DataTables, Forms, and Dropdowns based on DB relationships",
   "keywords": [
     "graphql",

--- a/src/scalarComponents/primereact/Float8Input.tsx
+++ b/src/scalarComponents/primereact/Float8Input.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import { bs } from '@tesseractcollective/react-graphql'
 import NumberInput from './NumberInput'
-import { ScalarComponentPropsBase } from '../../types/generic';
+import { ScalarComponentPropsBase } from '../../types/generic'
 
 export interface IFloat8InputProps extends ScalarComponentPropsBase {}
 
@@ -14,7 +14,8 @@ const Float8Input: FunctionComponent<IFloat8InputProps> = function Float8Input(
       {...props}
       inputNumberProps={{
         maxFractionDigits: 2,
-        ...props
+        minFractionDigits: 2,
+        ...props,
       }}
     />
   )


### PR DESCRIPTION
Just like the Float input type, Float8 input type also accepts decimal values as input.